### PR TITLE
Az adat modelleket tartalmazó Model mappa és a túraútvonal adatmodell létrehozva

### DIFF
--- a/evoHike.Backend/Models/Trail.cs
+++ b/evoHike.Backend/Models/Trail.cs
@@ -1,0 +1,26 @@
+namespace evoHike.Backend.Models
+{
+
+    public enum DifficultyLevel
+    {
+        Easy,
+        Medium,
+        Hard,
+        Expert
+    }
+
+    public class Trail
+    {
+        public int Id { get; set; }
+
+        public required string Name { get; set; }
+
+        public required string Location { get; set; }
+
+        public double Length { get; set; }
+
+        public DifficultyLevel Difficulty { get; set; }
+
+        public double Elevation { get; set; }
+    }
+}


### PR DESCRIPTION
Az nehézégi szint adatmodellt a trail classen kívül definiáltam, hogy könnyebben elérhető legyen, illetve a név és a lokáció string nem lehet null.